### PR TITLE
refactor: add redirect to projects page after delete

### DIFF
--- a/src/features/projects/remove/model/useRemoveProject.ts
+++ b/src/features/projects/remove/model/useRemoveProject.ts
@@ -1,5 +1,7 @@
 import { type DefaultError, useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { projectFabricKeys, ProjectHttp, type TProject } from 'entities/project';
+import { useRouter, usePathname } from 'next/navigation';
+import { routes } from 'shared/config';
 import { toast } from 'sonner';
 
 type RemoveProjectVariables = {
@@ -13,11 +15,19 @@ export type UseRemoveProjectOptions = Omit<
 >;
 
 export function useRemoveProject({ onSuccess, ...rest }: UseRemoveProjectOptions = {}) {
+  const router = useRouter();
+  const pathname = usePathname();
+
   return useMutation<TProject.ActionResponse, DefaultError, RemoveProjectVariables>({
     ...rest,
     mutationFn: ({ teamId, id }) => ProjectHttp.removeProject(teamId, id),
     onSuccess: async (res, variables, _r, context) => {
       onSuccess?.(res, variables, _r, context);
+
+      if (pathname !== routes.team.projects()) {
+        router.replace(routes.team.projects());
+      }
+
       toast.success(res.message ?? 'Проект удалён');
 
       await context.client.invalidateQueries({

--- a/src/features/projects/remove/ui/RemoveProjectDialog.tsx
+++ b/src/features/projects/remove/ui/RemoveProjectDialog.tsx
@@ -48,7 +48,11 @@ export function RemoveProjectDialog({ projectName, teamId, projectId, ...props }
         />
         <AlertDialogFooter>
           <AlertDialogCancel onClick={() => setInputValue('')}>Отмена</AlertDialogCancel>
-          <AlertDialogAction variant="destructive" disabled={!isMatch} onClick={onRemove}>
+          <AlertDialogAction
+            variant="destructive"
+            disabled={!isMatch || removeProject.isPending}
+            onClick={onRemove}
+          >
             Удалить
           </AlertDialogAction>
         </AlertDialogFooter>


### PR DESCRIPTION
## Что сделано

- Добавлен редирект на `/team/projects` после удаления проекта со страницы проекта (`/team/projects/[projectId]`, `/team/projects/[projectId]/settings`)

## Проверка

- [x] Редирект на `/team/projects/` после удаления проекта со страницы `/team/projects/[projectId]/settings`.
- [x] Редирект не происходит после удаления проекта со страницы `/team/projects`.
- [x] Кнопка "Удалить" не доступна, когда уже отправлен запрос на удаление проекта 