### PR TITLE
style: fix autofill background

### DIFF
--- a/src/app/styles/global.css
+++ b/src/app/styles/global.css
@@ -131,4 +131,7 @@
   .input-max-w {
     @apply md:max-w-[380px];
   }
+  input:-webkit-autofill {
+    @apply transition-[background-color] duration-[5000s];
+  }
 }


### PR DESCRIPTION
### Что сделано

- Устранён синий фон автозаполнения браузера.

### Зачем

* Браузер не позволяет перебить фон автофилла напрямую — заморозка transition скрывает его незаметно для пользователя.

### Проверка

- [ ] При автозаполнении синий фон не появляется.
- [x] Typecheck и линтеры проходят.